### PR TITLE
Add optional var for VM firewall

### DIFF
--- a/proxmox/vm/README.md
+++ b/proxmox/vm/README.md
@@ -169,6 +169,14 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_firewall_is_enabled"></a> [firewall\_is\_enabled](#input\_firewall\_is\_enabled)
+
+Description: Whether this interface's firewall rules should be used
+
+Type: `bool`
+
+Default: `false`
+
 ### <a name="input_memory"></a> [memory](#input\_memory)
 
 Description: The dedicated memory in megabytes

--- a/proxmox/vm/main.tf
+++ b/proxmox/vm/main.tf
@@ -127,7 +127,7 @@ resource "proxmox_virtual_environment_vm" "vm_resource" {
     # Available attributes:
     # disconnected = false
     # enabled      = true
-    # firewall     = false
+    firewall = var.firewall_is_enabled
     # mac_address  = "BC:24:11:42:95:87"
     # model        = "virtio"
     # mtu          = 0

--- a/proxmox/vm/vars.tf
+++ b/proxmox/vm/vars.tf
@@ -112,3 +112,9 @@ variable "cpu_type" {
   type        = string
   description = "The emulated CPU type. Some VMs need certain types of CPUs. See available values in [the provider docs](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_vm#host)."
 }
+
+variable "firewall_is_enabled" {
+  default     = false
+  type        = bool
+  description = "Whether this interface's firewall rules should be used"
+}


### PR DESCRIPTION
- Resolves #47

This PR adds an optional variable to enable/disable VM's firewall. Defaults to the provider's settings (`false`).